### PR TITLE
ci(release): approval-gated publish environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Deployment environment with a required reviewer: every publish run
+    # pauses for approval in the Actions UI before any step executes.
+    # Pinning this name in each package's npm trusted-publisher config
+    # makes npm reject OIDC claims from any other workflow shape.
+    environment: npm-publish
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -17,6 +17,11 @@ no OTP; provenance attestations are automatic.
 The workflow fails loudly if any package's version disagrees with the
 tag, and skips versions already published — re-running it is safe.
 
+The publish job runs in the `npm-publish` deployment environment, which
+requires an approval in the Actions UI before any step executes; the
+environment name is part of each package's trusted-publisher pin, so
+OIDC claims without it are rejected by npm.
+
 ## Trusted publisher configuration (one-time, per package)
 
 On npmjs.com: package → Settings → Trusted Publisher → GitHub Actions,
@@ -27,7 +32,7 @@ with exactly:
 | Organization or user | `dustyway` |
 | Repository | `remelonDB` |
 | Workflow filename | `release.yml` |
-| Environment name | (empty) |
+| Environment name | `npm-publish` |
 | Allowed actions | `npm publish` |
 
 Requirements baked into the workflow: npm ≥ 11.5.1 (upgraded in-job),


### PR DESCRIPTION
Publish job moves into the npm-publish environment (created, required reviewer configured). Merging this alone only adds the approval pause; the npm-side environment pin per package completes the enforcement (see docs/releasing.md table update in this PR). Note: merge after #1 (both touch docs/releasing.md, different sections).