### PR TITLE
docs(tutorial): name the single-owner rule the account-switch global relies on

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -551,10 +551,10 @@ logs straight in as another user is the case to watch: assigning a
 new manager over the old one leaves that database open with nothing
 pointing at it, held for the rest of the session. `onLogin` handles
 the sequential form by closing first, which is why it awaits
-`onLogout`. What no amount of care inside these two functions can fix
-is two transitions running concurrently, since each would then be
-closing and assigning under the other. Nothing in the browser
-serializes that for you.
+`onLogout`. This fragment does not serialize callers; the application
+must do that. Two transitions running concurrently would each be
+closing and assigning under the other, and a mutex or a promise queue
+around the pair is what prevents it.
 
 The second is that no other code path touches the variable. Add one,
 say a route guard reading the profile or a layout component, and "the
@@ -579,7 +579,12 @@ only when no suitable one is active, closing exactly the instance it
 created. Borrowing is not politeness. Where `SharedWorker` is
 unavailable the driver falls back to single-owner semantics, so a
 second open of a database that is already open fails rather than
-sharing. One thing not to borrow is a manager whose owner has already
+sharing. The same fallback constrains a private manager for a
+different database, because the SAH pool has one owner per origin
+rather than one per file: an open manager for the outgoing account
+can block a private manager for the incoming one. Close the outgoing
+account's manager before opening it. One thing not to borrow is a
+manager whose owner has already
 closed it: that manager is back at `idle`, which reads exactly like
 unstarted, and calling `init()` on it reopens a database nobody is
 left to close. A keyed, reference-counted registry that would move

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -519,6 +519,7 @@ arrival — closed immediately, its `init()` rejecting — so a slow open
 can never resurrect a database after logout:
 
 ```js fragment
+// One owner: only onLogin/onLogout may read, write, or close this.
 let manager = null
 
 function onLogin(userId) {
@@ -538,6 +539,27 @@ async function onLogout() {
   manager = null
 }
 ```
+
+That first comment is load-bearing. The fragment is safe only while
+the variable has exactly one owner. When `onLogin` and `onLogout` are
+the only code touching `manager`, "the current manager" and "the
+manager I created" are always the same object. Add a second code
+path, say a route guard reading the profile or a layout component,
+and the two meanings split. Now `onLogout`'s `manager?.close()` can
+tear down a database another caller is still using. The failure is
+quiet. `close()` returns the manager to `idle`, not to an error
+state, so a component still rendering that manager sees no error and
+no data. The screen is blank and nothing calls `init()` again.
+
+If more than one code path needs the database, strict rules keep the
+shared variable safe. One path writes it. Every other caller either
+receives a manager as an argument, or creates a private one and
+closes exactly the instance it created, never the global. Treat
+`idle` as absent. An idle manager is unstarted or closed, and
+adopting one reopens a database nobody will close. A keyed,
+reference-counted registry that moves this from caller discipline
+into the library is planned
+([#32](https://github.com/dustyway/remelonDB/issues/32)).
 
 ## Where next
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -584,10 +584,9 @@ different database, because the SAH pool has one owner per origin
 rather than one per file: an open manager for the outgoing account
 can block a private manager for the incoming one. Close the outgoing
 account's manager before opening it. One thing not to borrow is a
-manager whose owner has already
-closed it: that manager is back at `idle`, which reads exactly like
-unstarted, and calling `init()` on it reopens a database nobody is
-left to close. A keyed, reference-counted registry that would move
+manager whose owner has already closed it. That manager is back at
+`idle`, which reads exactly like unstarted, so calling `init()` on it
+reopens a database nobody is left to close. A keyed, reference-counted registry that would move
 these rules out of caller discipline and into the library is under
 discussion ([#32](https://github.com/dustyway/remelonDB/issues/32)).
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -543,26 +543,28 @@ async function onLogout() {
 }
 ```
 
-That first comment is load-bearing. The fragment is safe only while
-the variable has exactly one owner. When `onLogin` and `onLogout` are
-the only code touching `manager`, "the current manager" and "the
-manager I created" are always the same object. Add a second code
-path, say a route guard reading the profile or a layout component,
-and the two meanings split. Now `onLogout`'s `close()` can tear down
-a database another caller is still using. The failure is quiet.
-`close()` returns the manager to `idle`, not to an error state, so a
-component still rendering that manager sees no error and no data. The
-screen is blank and nothing calls `init()` again.
+That first comment is load-bearing, and it asks for two things. The
+first is that account transitions run one at a time, including a
+switch that logs straight in as another user without logging out
+first. Two overlapping `onLogin` calls leave the second manager in
+the variable and the first one open with nothing pointing at it, so
+that database stays held and no one can close it. Nothing in the
+browser serializes this for you.
 
-One owner is necessary but not sufficient, because that owner's own
-turns can overlap. A login that starts while a logout waits on
-`close()` puts a new manager in the variable, and a bare
-`manager = null` after the await would discard it. The fragment
-compares before it clears, which is the general rule: clear a shared
-reference only while it still points at what you closed. An
-application that serializes account transitions, so a logout always
-finishes before the next login begins, does not need the comparison,
-but nothing in the browser enforces that for you.
+The second is that no other code path touches the variable. Add one,
+say a route guard reading the profile or a layout component, and "the
+current manager" and "the manager I created" stop being the same
+object. Now `onLogout`'s `close()` can tear down a database another
+caller is still using. The failure is quiet. `close()` returns the
+manager to `idle`, not to an error state, so a component still
+rendering that manager sees no error and no data. The screen is blank
+and nothing calls `init()` again.
+
+The comparison in `onLogout` is the backstop for when that discipline
+slips. A login that begins while the logout waits on `close()`
+installs a new manager, and a bare `manager = null` afterwards would
+discard it. Clearing a shared reference only while it still points at
+what you closed costs one line and settles the question.
 
 If more than one code path needs the database, the rules get
 stricter. One path owns the variable and is the only one that writes

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -535,8 +535,11 @@ function onLogin(userId) {
 }
 
 async function onLogout() {
-  await manager?.close()
-  manager = null
+  const closing = manager
+  await closing?.close()
+  if (manager === closing) {
+    manager = null   // a login during the await owns the variable now
+  }
 }
 ```
 
@@ -545,21 +548,36 @@ the variable has exactly one owner. When `onLogin` and `onLogout` are
 the only code touching `manager`, "the current manager" and "the
 manager I created" are always the same object. Add a second code
 path, say a route guard reading the profile or a layout component,
-and the two meanings split. Now `onLogout`'s `manager?.close()` can
-tear down a database another caller is still using. The failure is
-quiet. `close()` returns the manager to `idle`, not to an error
-state, so a component still rendering that manager sees no error and
-no data. The screen is blank and nothing calls `init()` again.
+and the two meanings split. Now `onLogout`'s `close()` can tear down
+a database another caller is still using. The failure is quiet.
+`close()` returns the manager to `idle`, not to an error state, so a
+component still rendering that manager sees no error and no data. The
+screen is blank and nothing calls `init()` again.
 
-If more than one code path needs the database, strict rules keep the
-shared variable safe. One path writes it. Every other caller either
-receives a manager as an argument, or creates a private one and
-closes exactly the instance it created, never the global. Treat
-`idle` as absent. An idle manager is unstarted or closed, and
-adopting one reopens a database nobody will close. A keyed,
-reference-counted registry that moves this from caller discipline
-into the library is planned
-([#32](https://github.com/dustyway/remelonDB/issues/32)).
+One owner is necessary but not sufficient, because that owner's own
+turns can overlap. A login that starts while a logout waits on
+`close()` puts a new manager in the variable, and a bare
+`manager = null` after the await would discard it. The fragment
+compares before it clears, which is the general rule: clear a shared
+reference only while it still points at what you closed. An
+application that serializes account transitions, so a logout always
+finishes before the next login begins, does not need the comparison,
+but nothing in the browser enforces that for you.
+
+If more than one code path needs the database, the rules get
+stricter. One path owns the variable and is the only one that writes
+it. Every other caller borrows: it uses the active manager for the
+same database and never closes it, and it creates a private manager
+only when no suitable one is active, closing exactly the instance it
+created. Borrowing is not politeness. Where `SharedWorker` is
+unavailable the driver falls back to single-owner semantics, so a
+second open of a database that is already open fails rather than
+sharing. One thing not to borrow is a manager whose owner has already
+closed it: that manager is back at `idle`, which reads exactly like
+unstarted, and calling `init()` on it reopens a database nobody is
+left to close. A keyed, reference-counted registry that would move
+these rules out of caller discipline and into the library is under
+discussion ([#32](https://github.com/dustyway/remelonDB/issues/32)).
 
 ## Where next
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -519,10 +519,12 @@ arrival — closed immediately, its `init()` rejecting — so a slow open
 can never resurrect a database after logout:
 
 ```js fragment
-// One owner: only onLogin/onLogout may read, write, or close this.
+// One owner (only onLogin/onLogout touch this) and one transition at
+// a time: never let two of them run concurrently.
 let manager = null
 
-function onLogin(userId) {
+async function onLogin(userId) {
+  await onLogout()   // an account switch closes the old database first
   const name = `user_${hex(userId)}.db`
   manager = createDatabaseManager({
     open: (onTakenOver) =>
@@ -544,12 +546,15 @@ async function onLogout() {
 ```
 
 That first comment is load-bearing, and it asks for two things. The
-first is that account transitions run one at a time, including a
-switch that logs straight in as another user without logging out
-first. Two overlapping `onLogin` calls leave the second manager in
-the variable and the first one open with nothing pointing at it, so
-that database stays held and no one can close it. Nothing in the
-browser serializes this for you.
+first is that account transitions run one at a time. A switch that
+logs straight in as another user is the case to watch: assigning a
+new manager over the old one leaves that database open with nothing
+pointing at it, held for the rest of the session. `onLogin` handles
+the sequential form by closing first, which is why it awaits
+`onLogout`. What no amount of care inside these two functions can fix
+is two transitions running concurrently, since each would then be
+closing and assigning under the other. Nothing in the browser
+serializes that for you.
 
 The second is that no other code path touches the variable. Add one,
 say a route guard reading the profile or a layout component, and "the


### PR DESCRIPTION
The "Multiple accounts on one device" fragment keeps a manager in a
module global and never says what makes that safe: `onLogin` and
`onLogout` are its only readers and writers. Copied into an app where
other code paths also touch the variable, "the current manager" and
"the manager I created" stop being the same object, and one caller's
`close()` can tear down a database another caller is still rendering.

The failure is quiet, which is what makes it worth documenting.
`close()` returns the manager to `idle` rather than to an error state,
so a component holding that manager sees no error and no data. The
screen goes blank and nothing calls `init()` again.

The fragment also had two bugs it now warns about. `onLogout` awaited
`close()` and then set the variable to `null`, so a login starting
during that await lost its manager; it now compares before clearing.
And `onLogin` assigned over the previous manager, so logging straight
in as a second user left the first database open with nothing pointing
at it; it now awaits `onLogout` first.

Changes: the two fragment fixes, a comment inside the fragment stating
both requirements (one owner, one transition at a time) where it
travels with the code people copy, and a prose section covering
serialization as the application's job, borrowing an active manager
rather than opening a duplicate, the per-origin SAH pool constraint,
and the narrow case where a manager must not be adopted. No library
API or runtime changes; the fragment's own behavior does change.

Context, neither of which this PR closes:

- dustyway/remelonDB#32 proposes moving these rules out of caller
  discipline and into a keyed, reference-counted registry. That design
  is under discussion, so the docs point at it as proposed rather than
  describing it as available.
- NotAnotherCards/NotAnotherCards#140 prompted this. A module-level
  test there proves the wrong-referent close is reachable; the full
  router and OAuth flows have not been reproduced end to end, so treat
  it as the mechanism the code permits rather than the confirmed cause
  of every report. The docs text names no consumer and stands on the
  mechanism alone.

## Verification

`pnpm check:tutorial` passes locally at this branch head (48cc09c).
That is a weaker signal than it looks: the edited example carries the
`js fragment` marker, so the checker skips it. The local pass confirms
the other twelve blocks still run. **The changed fragment is validated
by manual review only.**

CI does not attach to pull requests in this repo, since `ci.yml`
triggers on `push` to `main` and `workflow_dispatch` only (see
dustyway/remelonDB#34). Earlier commits on this branch were dispatched
and came back green; the last two commits are prose and fragment edits
that no automated lane covers, so they were not dispatched again. A
dispatch forces every gated job regardless of paths. On a push, this
change would run three jobs: `changes`, `test`, and `pack-consume`,
the last because the `packages` filter includes `docs/tutorial.md` and
that job runs `check:tutorial`.
