### PR TITLE
feat(core): a per-database randomSource option

### DIFF
--- a/docs/reference/runtimes.md
+++ b/docs/reference/runtimes.md
@@ -13,12 +13,12 @@ supply.
 
 ES2022 syntax and standard library, plus these host globals:
 
-| Global | Used for |
-| --- | --- |
-| `Promise`, `queueMicrotask` | the write queue and every async seam |
+| Global                                                 | Used for                                       |
+| ------------------------------------------------------ | ---------------------------------------------- |
+| `Promise`, `queueMicrotask`                            | the write queue and every async seam           |
 | `AbortController`, `AbortSignal` (`aborted`, `reason`) | cancelling a sync run when its owner goes away |
-| `setTimeout`, `clearTimeout` | the sync controller's interval and debounce |
-| `JSON` | wire payloads and `fields_json` columns |
+| `setTimeout`, `clearTimeout`                           | the sync controller's interval and debounce    |
+| `JSON`                                                 | wire payloads and `fields_json` columns        |
 
 Anything outside that list belongs to a driver, not to core. `URL` and
 `Worker` appear in `@remelondb/driver-web` because the web driver runs
@@ -35,30 +35,40 @@ abort checks should do the same.
 
 **`crypto.getRandomValues` is absent on React Native.** Hermes provides no
 WebCrypto, and neither Expo SDK 57 nor React Native 0.86 installs a
-polyfill: `globalThis.crypto` is `undefined` there. `randomId()` requires
-it, so a React Native app provides one before opening a database. Two
-ways, matching the two ways an Expo app runs.
-
-In Expo Go, `expo-crypto` is already present and can define the global:
+polyfill: `globalThis.crypto` is `undefined` there. Record ids need random
+bytes, so a React Native app supplies them. The preferred way is the
+`randomSource` option, no global involved:
 
 ```ts
 import * as Crypto from 'expo-crypto';
 
-if (typeof globalThis.crypto?.getRandomValues !== 'function') {
-  globalThis.crypto = { getRandomValues: Crypto.getRandomValues } as Crypto;
-}
+const db = await Database.open({
+  driver,
+  schema,
+  name,
+  randomSource: Crypto.getRandomValues,
+});
 ```
 
-In a development build or a bare app, `react-native-get-random-values`
-does the same as a native module, which makes installing it a build
-change: rebuild Android or run `pod install`, then import it first. Adding
-the import without rebuilding fails with
+Every id the database mints goes through that source, and an app that
+derives ids itself calls `database.randomId()` rather than the module-level
+`randomId()`, so the configured source covers those too. `expo-crypto`'s
+function is free-standing; a browser's or Node's is a method and must be
+bound if passed (`crypto.getRandomValues.bind(crypto)`), though on those
+runtimes the ambient default already works and the option is unnecessary.
+
+The older way still works: define the global before opening. In Expo Go,
+`expo-crypto` can back it; in a development build or a bare app,
+`react-native-get-random-values` does the same as a native module, which
+makes installing it a build change: rebuild Android or run `pod install`,
+then import it first. Adding the import without rebuilding fails with
 `TurboModuleRegistry.getEnforcing(...): 'RNGetRandomValues' could not be
 found`, the JS half arriving without the native half.
 
-`Database.open` probes the source with one byte before it touches the
-driver, so both failures surface at startup with nothing opened, each with
-a message naming its fix, rather than at the first record an app creates.
+`Database.open` probes whichever source it will use with one byte before
+it touches the driver, so every failure shape surfaces at startup with
+nothing opened, each with a message naming its fix, rather than at the
+first record an app creates.
 
 There is no `Math.random()` fallback. Ids identify records across devices,
 and a library substituting a weaker source without saying so is worse than

--- a/packages/core/src/database/Collection.ts
+++ b/packages/core/src/database/Collection.ts
@@ -134,7 +134,7 @@ export class Collection<M = RawRecord, C extends string = string> {
     ) {
       stamped['updated_at'] = now;
     }
-    const raw = sanitizedRaw(stamped, this.schema);
+    const raw = sanitizedRaw(stamped, this.schema, this.database.randomSource);
     raw._status = 'created';
     raw._changed = '';
     return { type: 'create', table: this.table, raw };

--- a/packages/core/src/database/Database.ts
+++ b/packages/core/src/database/Database.ts
@@ -16,7 +16,11 @@ import type {
   SqlArgs,
   SqliteDriver,
 } from '../driver/SqliteDriver';
-import { fillRandomValues } from '../utils/randomId';
+import {
+  fillRandomValues,
+  randomId,
+  type RandomSource,
+} from '../utils/randomId';
 import type {
   AppSchema,
   ColumnName,
@@ -62,6 +66,13 @@ export interface DatabaseOptions {
   readonly name: string;
   /** Optional, passive instrumentation for reactive query refetches. */
   readonly onObservation?: (event: ObservationDiagnostic) => void;
+  /**
+   * App-supplied random filler for record ids, replacing the ambient
+   * `globalThis.crypto.getRandomValues` (which stays the default). Lets
+   * React Native apps pass e.g. `expo-crypto`'s `getRandomValues` instead
+   * of installing a global polyfill (#47).
+   */
+  readonly randomSource?: RandomSource;
 }
 
 export interface ObservationDiagnostic {
@@ -124,6 +135,7 @@ export class Database {
     associations: readonly QueryAssociation[],
     readonly migrations?: SchemaMigrations,
     readonly onObservation?: (event: ObservationDiagnostic) => void,
+    readonly randomSource?: RandomSource,
   ) {
     this.associations = associations;
     this.localStorage = new LocalStorage(driver);
@@ -138,14 +150,26 @@ export class Database {
     }
   }
 
+  /**
+   * A 16-character record id from this database's random source (the
+   * `randomSource` option, or the ambient WebCrypto default). Apps that
+   * mint ids themselves, e.g. to derive deterministic child ids, use this
+   * instead of the module-level `randomId` so a configured source covers
+   * every id (#47).
+   */
+  randomId(): string {
+    return randomId(this.randomSource);
+  }
+
   /** Open the database, running setup or migrations as needed. */
   static async open(options: DatabaseOptions): Promise<Database> {
-    const { driver, schema, migrations, name } = options;
+    const { driver, schema, migrations, name, randomSource } = options;
     // One probe byte before the driver opens anything: a runtime without
     // a working random source cannot create records, and learning that at
     // the first save, with a database already open, is the failure this
-    // prevents.
-    fillRandomValues(new Uint8Array(1));
+    // prevents. The probe exercises whichever source this database will
+    // actually use.
+    fillRandomValues(new Uint8Array(1), randomSource);
     const { userVersion } = await driver.open(name);
 
     if (userVersion === 0) {
@@ -204,6 +228,7 @@ export class Database {
       associations,
       migrations,
       options.onObservation,
+      randomSource,
     );
     for (const modelClass of options.modelClasses ?? []) {
       database.get(modelClass.table)._bindModelClass(modelClass);

--- a/packages/core/src/database/openRandomSource.test.ts
+++ b/packages/core/src/database/openRandomSource.test.ts
@@ -50,3 +50,64 @@ describe('Database.open random-source probe', () => {
     expect(driver.open).not.toHaveBeenCalled();
   });
 });
+
+describe('the randomSource option (#47)', () => {
+  const workingDriver = () =>
+    ({
+      open: vi.fn(async () => ({ userVersion: schema.version })),
+      close: vi.fn(async () => {}),
+      query: vi.fn(async () => []),
+      execute: vi.fn(async () => {}),
+      executeBatch: vi.fn(async () => {}),
+      setUserVersion: vi.fn(async () => {}),
+      destroy: vi.fn(async () => {}),
+    }) as unknown as SqliteDriver;
+
+  it('opens and creates records without any ambient crypto', async () => {
+    setCrypto(undefined);
+    let counter = 0;
+    const source = vi.fn((bytes: Uint8Array) => bytes.fill(counter++));
+    const db = await Database.open({
+      driver: workingDriver(),
+      schema,
+      name: 'source.db',
+      randomSource: source,
+    });
+    // the probe used the source, not the (absent) global
+    expect(source).toHaveBeenCalledTimes(1);
+
+    const op = db.get('tasks').prepareCreate({ name: 'x' });
+    expect(op.raw.id).toBe('b'.repeat(16));
+    expect(db.randomId()).toBe('c'.repeat(16));
+    expect(source).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects before driver.open when the source throws', async () => {
+    const driver = driverThatMustNotOpen();
+    await expect(
+      Database.open({
+        driver,
+        schema,
+        name: 'source.db',
+        randomSource: () => {
+          throw new Error('no native module');
+        },
+      }),
+    ).rejects.toThrowError(/randomSource passed/);
+    expect(driver.open).not.toHaveBeenCalled();
+  });
+
+  it('a passed source wins over the ambient crypto', async () => {
+    const ambient = vi.fn();
+    setCrypto({ getRandomValues: ambient });
+    const source = vi.fn((bytes: Uint8Array) => bytes.fill(0));
+    await Database.open({
+      driver: workingDriver(),
+      schema,
+      name: 'source.db',
+      randomSource: source,
+    });
+    expect(source).toHaveBeenCalled();
+    expect(ambient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,7 +65,7 @@ export {
 } from './rawRecord/index';
 export type { RawRecord, DirtyRaw, SyncStatus } from './rawRecord/index';
 
-export { randomId } from './utils/randomId';
+export { randomId, type RandomSource } from './utils/randomId';
 
 export { Database } from './database/Database';
 export { createDatabaseManager } from './database/DatabaseManager';

--- a/packages/core/src/rawRecord/index.ts
+++ b/packages/core/src/rawRecord/index.ts
@@ -11,7 +11,7 @@
  */
 import type { SqlValue } from '../driver/SqliteDriver';
 import type { ColumnSchema, TableSchema } from '../schema/index';
-import { randomId } from '../utils/randomId';
+import { randomId, type RandomSource } from '../utils/randomId';
 
 export type SyncStatus = 'synced' | 'created' | 'updated' | 'deleted';
 
@@ -76,12 +76,16 @@ function isSyncStatus(value: unknown): value is SyncStatus {
   );
 }
 
-export function sanitizedRaw(dirty: DirtyRaw, table: TableSchema): RawRecord {
+export function sanitizedRaw(
+  dirty: DirtyRaw,
+  table: TableSchema,
+  randomSource?: RandomSource,
+): RawRecord {
   const id = dirty['id'];
   const status = dirty['_status'];
   const changed = dirty['_changed'];
   const raw: RawRecord = {
-    id: typeof id === 'string' && id !== '' ? id : randomId(),
+    id: typeof id === 'string' && id !== '' ? id : randomId(randomSource),
     _status: isSyncStatus(status) ? status : 'created',
     _changed: typeof changed === 'string' ? changed : '',
   };

--- a/packages/core/src/utils/randomId.test.ts
+++ b/packages/core/src/utils/randomId.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fillRandomValues, randomId } from './randomId';
 
 const realCrypto = globalThis.crypto;
@@ -47,5 +47,49 @@ describe('fillRandomValues', () => {
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toMatch(/without rebuilding/);
     expect((caught as Error).cause).toBe(native);
+  });
+});
+
+describe('randomId with an app-supplied source', () => {
+  it('uses the source instead of the ambient crypto', () => {
+    const source = vi.fn((bytes: Uint8Array) => bytes.fill(0));
+    expect(randomId(source)).toBe('a'.repeat(16));
+    expect(source).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps a throwing source in the native-module hint', () => {
+    const source = () => {
+      throw new Error('missing native module');
+    };
+    expect(() => randomId(source)).toThrowError(/randomSource passed/);
+  });
+
+  it('rejects an async source instead of minting ids from a zeroed buffer', () => {
+    const source = ((bytes: Uint8Array) =>
+      Promise.resolve(bytes)) as unknown as (bytes: Uint8Array) => Uint8Array;
+    expect(() => randomId(source)).toThrowError(/synchronously/);
+  });
+
+  it('rejects a source that fills a copy instead of the given array', () => {
+    const source = (bytes: Uint8Array) => new Uint8Array(bytes.length).fill(3);
+    expect(() => randomId(source)).toThrowError(/return it/);
+  });
+
+  it('ignores the ambient crypto entirely when a source is given', () => {
+    setCrypto(undefined);
+    const source = (bytes: Uint8Array) => bytes.fill(1);
+    expect(randomId(source)).toBe('b'.repeat(16));
+  });
+});
+
+describe('an unbound web-style source', () => {
+  it('fails with the bind hint instead of silently misbehaving', () => {
+    const unbound = globalThis.crypto.getRandomValues;
+    expect(() => randomId(unbound)).toThrowError(/bind/);
+  });
+
+  it('works when bound', () => {
+    const bound = globalThis.crypto.getRandomValues.bind(globalThis.crypto);
+    expect(randomId(bound)).toMatch(/^[a-z0-9]{16}$/);
   });
 });

--- a/packages/core/src/utils/randomId.ts
+++ b/packages/core/src/utils/randomId.ts
@@ -1,6 +1,16 @@
 const ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
 /**
+ * An app-supplied random filler, `crypto.getRandomValues`-shaped: it
+ * fills the array it is given synchronously and returns that same array,
+ * which is what `crypto.getRandomValues` and `expo-crypto`'s
+ * `getRandomValues` both do. The return value is checked at runtime so
+ * an async source, which would leave the buffer zeroed and make every id
+ * identical, fails loudly instead.
+ */
+export type RandomSource = (bytes: Uint8Array) => Uint8Array;
+
+/**
  * Fill `bytes` from `crypto.getRandomValues`, the one host capability
  * remelonDB needs that it does not receive through an option.
  *
@@ -12,7 +22,33 @@ const ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
  * polyfill's JS half arrived without its native half, which is what an
  * un-rebuilt React Native app looks like.
  */
-export function fillRandomValues(bytes: Uint8Array): void {
+export function fillRandomValues(
+  bytes: Uint8Array,
+  source?: RandomSource,
+): void {
+  if (source) {
+    let result: Uint8Array;
+    try {
+      result = source(bytes);
+    } catch (cause) {
+      throw new Error(
+        'the randomSource passed to Database.open failed. A browser or ' +
+          'Node crypto.getRandomValues must be bound first: pass ' +
+          'crypto.getRandomValues.bind(crypto). On React Native this ' +
+          'usually means a native module is missing from the build.',
+        { cause },
+      );
+    }
+    if (result !== bytes) {
+      throw new Error(
+        'the randomSource passed to Database.open must fill the given ' +
+          'array synchronously and return it, as crypto.getRandomValues ' +
+          'does. An async source cannot work: ids would be read before ' +
+          'it resolves.',
+      );
+    }
+    return;
+  }
   const crypto = globalThis.crypto;
   if (typeof crypto?.getRandomValues !== 'function') {
     throw new Error(
@@ -35,9 +71,9 @@ export function fillRandomValues(bytes: Uint8Array): void {
 }
 
 /** 16-character record id, format-compatible with upstream WatermelonDB. */
-export function randomId(): string {
+export function randomId(source?: RandomSource): string {
   const bytes = new Uint8Array(16);
-  fillRandomValues(bytes);
+  fillRandomValues(bytes, source);
   let id = '';
   for (let i = 0; i < bytes.length; i++) {
     id += ALPHABET[bytes[i]! % ALPHABET.length]!;


### PR DESCRIPTION
Closes #47.

`Database.open({ randomSource })` replaces the ambient `crypto.getRandomValues` for every id the database mints. Per-database as the issue asked, no module-level setter; the global stays the default, so browsers and Node change nothing.

- The open-time probe exercises whichever source the database will use, so every failure shape still surfaces at startup with nothing opened.
- `database.randomId()` covers app-side minting (deterministic child ids), so a configured source covers every id.
- The source contract is synchronous: fill the given array and return it, `crypto.getRandomValues`-shaped. Checked at runtime, so an async source or an unbound browser method fails loudly with a message naming its fix, instead of minting identical ids from a zeroed buffer.
- `applyRemoteChanges` stays off the entropy path: remote ids are validated before the sanitize, so that branch cannot mint.
- docs/reference/runtimes.md now leads with the option as the preferred way on React Native; the global shim remains documented.

Verified: 200 core tests (11 on the source contract), typecheck, build, prettier, guide check.
