### PR TITLE
chore: clear the lint ratchet, rules to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,9 +2,9 @@ import tseslint from 'typescript-eslint';
 
 // Lint scope is packages/*/src only, deliberately: driver-rn-cpp/e2e, the
 // doc-check scripts, and examples have no project service and join later
-// if wanted (#53). The gate is `pnpm lint`, which enforces a warning
-// ceiling; the two warn-level rules below are ratchets, lowered package
-// by package in the #53 cleanup, not permanent allowances.
+// if wanted (#53). The gate is `pnpm lint`, which allows no warnings at
+// all: the two rules that were ratchets during the #53 cleanup are now
+// errors like the rest.
 export default tseslint.config(
   {
     ignores: ['**/dist/**', '**/node_modules/**', '**/e2e/**', 'scripts/**'],
@@ -28,12 +28,11 @@ export default tseslint.config(
         'error',
         { allowNumber: true },
       ],
-      // Ratchets (#53 phase 2): each package's cleanup turns its casts
-      // into narrows or reasoned disables, then the CI warning ceiling
-      // drops. `!` is the sanctioned escape for noUncheckedIndexedAccess,
-      // so each one is a judgment call, not a mechanical fix.
-      '@typescript-eslint/no-unsafe-type-assertion': 'warn',
-      '@typescript-eslint/no-non-null-assertion': 'warn',
+      // Cleared in #53 phase 2 and held at error since: every remaining
+      // cast and `!` in packages/*/src carries an eslint-disable line
+      // saying why it is safe. Adding one means writing that line.
+      '@typescript-eslint/no-unsafe-type-assertion': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'error',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "guide:epub": "pandoc docs/codebase-guide.md -o remelondb-guide.epub --toc --toc-depth=2 -N --resource-path=docs --css docs/codebase-guide.epub.css",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
-    "lint": "eslint --max-warnings 101 'packages/*/src/**/*.ts'"
+    "lint": "eslint --max-warnings 97 'packages/*/src/**/*.ts'"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "guide:epub": "pandoc docs/codebase-guide.md -o remelondb-guide.epub --toc --toc-depth=2 -N --resource-path=docs --css docs/codebase-guide.epub.css",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
-    "lint": "eslint --max-warnings 105 'packages/*/src/**/*.ts'"
+    "lint": "eslint --max-warnings 104 'packages/*/src/**/*.ts'"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "guide:epub": "pandoc docs/codebase-guide.md -o remelondb-guide.epub --toc --toc-depth=2 -N --resource-path=docs --css docs/codebase-guide.epub.css",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
-    "lint": "eslint --max-warnings 42 'packages/*/src/**/*.ts'"
+    "lint": "eslint --max-warnings 0 'packages/*/src/**/*.ts'"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "guide:epub": "pandoc docs/codebase-guide.md -o remelondb-guide.epub --toc --toc-depth=2 -N --resource-path=docs --css docs/codebase-guide.epub.css",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
-    "lint": "eslint --max-warnings 97 'packages/*/src/**/*.ts'"
+    "lint": "eslint --max-warnings 82 'packages/*/src/**/*.ts'"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "guide:epub": "pandoc docs/codebase-guide.md -o remelondb-guide.epub --toc --toc-depth=2 -N --resource-path=docs --css docs/codebase-guide.epub.css",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
-    "lint": "eslint --max-warnings 104 'packages/*/src/**/*.ts'"
+    "lint": "eslint --max-warnings 101 'packages/*/src/**/*.ts'"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "guide:epub": "pandoc docs/codebase-guide.md -o remelondb-guide.epub --toc --toc-depth=2 -N --resource-path=docs --css docs/codebase-guide.epub.css",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
-    "lint": "eslint --max-warnings 82 'packages/*/src/**/*.ts'"
+    "lint": "eslint --max-warnings 67 'packages/*/src/**/*.ts'"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "guide:epub": "pandoc docs/codebase-guide.md -o remelondb-guide.epub --toc --toc-depth=2 -N --resource-path=docs --css docs/codebase-guide.epub.css",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
-    "lint": "eslint --max-warnings 67 'packages/*/src/**/*.ts'"
+    "lint": "eslint --max-warnings 42 'packages/*/src/**/*.ts'"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "guide:epub": "pandoc docs/codebase-guide.md -o remelondb-guide.epub --toc --toc-depth=2 -N --resource-path=docs --css docs/codebase-guide.epub.css",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,tsx}\" \"packages/*/e2e/**/*.{ts,tsx}\" \"examples/**/*.{ts,tsx}\" \"scripts/**/*.mjs\"",
-    "lint": "eslint --max-warnings 107 'packages/*/src/**/*.ts'"
+    "lint": "eslint --max-warnings 105 'packages/*/src/**/*.ts'"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/packages/core/src/conformance/recordsSuite.ts
+++ b/packages/core/src/conformance/recordsSuite.ts
@@ -67,6 +67,7 @@ export function recordsSuite(options: ResolvedOptions): void {
       const rows = await driver.query(sql, args);
       expect(rows).toHaveLength(1);
       expect(rows[0]?.['is_done']).toBe(1); // stored representation
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the toHaveLength(1) above.
       expect(sanitizedRaw(rows[0]!, tasksTable)).toEqual(raw);
     });
   });

--- a/packages/core/src/conformance/schemaSuite.ts
+++ b/packages/core/src/conformance/schemaSuite.ts
@@ -108,6 +108,7 @@ export function schemaSuite(options: ResolvedOptions): void {
 
       const steps = stepsForMigration(migrations, { from: 1, to: 3 });
       expect(steps).not.toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the not.toBeNull() above.
       await driver.executeBatch(asBatch(encodeMigrationSteps(steps!)));
       await driver.setUserVersion(3);
 

--- a/packages/core/src/database/Collection.ts
+++ b/packages/core/src/database/Collection.ts
@@ -78,13 +78,16 @@ export class Collection<M = RawRecord, C extends string = string> {
   /** @internal Raw → public record type (Model when bound, raw otherwise). */
   _recordFor(raw: RawRecord): M {
     if (!this.modelClass) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- M is RawRecord exactly when the collection is unbound, which is what this branch tests; the pairing lives in the type, not in a value.
       return raw as M;
     }
     let model = this.models.get(raw.id);
     if (!model) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- a model constructor takes the erased collection; M's own model class is what produced it.
       model = new this.modelClass(this as Collection<Model>, raw);
       this.models.set(raw.id, model);
     }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- bound collections have M = their model class, which is what `this.modelClass` constructs.
     return model as M;
   }
 
@@ -99,6 +102,7 @@ export class Collection<M = RawRecord, C extends string = string> {
       return cached;
     }
     // 'id' is in every table's ColumnName union, but C is generic here
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- per the comment above: 'id' is in every table's column union, but C is not resolved here.
     const raws = await this.query(Q.where('id', id) as Clause<C>).fetchRaws();
     const raw = raws[0];
     if (!raw) {

--- a/packages/core/src/database/Database.ts
+++ b/packages/core/src/database/Database.ts
@@ -231,6 +231,7 @@ export class Database {
     // failed external apply must never take down the driver's listener.
     driver.onExternalChanges?.((changes) => {
       void database
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- a driver reports external changes with table names it cannot type; the comment above covers the unknown-table case.
         .applyExternalChanges(changes as DatabaseChangeSet)
         .catch(() => {});
     });
@@ -439,9 +440,11 @@ export class Database {
     const changesByTable = new Map<string, CollectionChange[]>();
     for (const operation of operations) {
       const collection = this.get(operation.table);
-      const changes =
-        changesByTable.get(operation.table) ??
-        changesByTable.set(operation.table, []).get(operation.table)!;
+      let changes = changesByTable.get(operation.table);
+      if (!changes) {
+        changes = [];
+        changesByTable.set(operation.table, changes);
+      }
       switch (operation.type) {
         case 'create':
           collection.cache.add(operation.raw);
@@ -455,6 +458,7 @@ export class Database {
             collection.cache.add(operation.raw);
           }
           changes.push({
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- both branches above leave this id in the cache: one updates the cached instance, the other adds the raw.
             record: collection.cache.get(operation.raw.id)!,
             type: 'updated',
           });
@@ -513,6 +517,7 @@ export class Database {
                 collection.cache.add(raw);
               }
               applied.push({
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the branches above leave this id in the cache: cached stays, uncached is added.
                 record: collection.cache.get(raw.id)!,
                 type: cached ? 'updated' : 'created',
               });

--- a/packages/core/src/database/Query.ts
+++ b/packages/core/src/database/Query.ts
@@ -116,11 +116,13 @@ export class Query<M = RawRecord> {
     };
 
     const differs = (records: readonly RawRecord[]): boolean => {
-      if (previous === null || previous.length !== records.length) {
+      const snapshot = previous;
+      if (snapshot === null || snapshot.length !== records.length) {
         return true;
       }
       return records.some((raw, index) => {
-        const before = previous![index]!;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the lengths were just compared equal.
+        const before = snapshot[index]!;
         return (
           before.raw !== raw ||
           columns.some((name) => before.content[name] !== raw[name])

--- a/packages/core/src/database/WorkQueue.ts
+++ b/packages/core/src/database/WorkQueue.ts
@@ -30,6 +30,7 @@ export class WorkQueue {
       this.queue.push({
         work,
         isWriter,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- one queue holds work of every result type at once, so the entry erases T; `enqueue<T>` re-applies it at the call site.
         resolve: resolve as (value: unknown) => void,
         reject,
       });

--- a/packages/core/src/model/Model.ts
+++ b/packages/core/src/model/Model.ts
@@ -86,6 +86,7 @@ export function ModelFor<T extends TableSchema>(schema: T): TypedModelClass<T> {
     static override readonly table = schema.name;
     static override readonly schema = schema;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the returned class IS `Bound`; the assertion only adds the schema-derived accessors this factory exists to declare.
   return Bound as unknown as TypedModelClass<T>;
 }
 
@@ -197,6 +198,7 @@ export class Model {
   }
 
   private association(table: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- a Model instance's constructor is its own model class.
     const associations = (this.constructor as ModelClass).associations;
     const association = associations?.[table];
     if (!association) {

--- a/packages/core/src/query/Q.ts
+++ b/packages/core/src/query/Q.ts
@@ -204,6 +204,7 @@ function ensureConditions(
       );
     }
   }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the loop above checked every clause's discriminant, which is all `Where` constrains.
   return clauses as readonly Where[];
 }
 
@@ -216,7 +217,7 @@ export function where<C extends string>(
     : eq(ensureValue(valueOrComparisonArg));
   return {
     type: 'where',
-    left: ensureName(left, 'column') as C,
+    left: ensureName(left, 'column'),
     comparison: comp,
   };
 }
@@ -224,6 +225,7 @@ export function where<C extends string>(
 export function and<C extends string>(...conditions: Where<C>[]): And<C> {
   return {
     type: 'and',
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the conditions came in as `Where<C>[]`; ensureConditions returns its own argument, having only rechecked it for JavaScript callers.
     conditions: ensureConditions(conditions, 'Q.and') as readonly Where<C>[],
   };
 }
@@ -231,6 +233,7 @@ export function and<C extends string>(...conditions: Where<C>[]): And<C> {
 export function or<C extends string>(...conditions: Where<C>[]): Or<C> {
   return {
     type: 'or',
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- as in Q.and: ensureConditions returns the same `Where<C>[]` it was given.
     conditions: ensureConditions(conditions, 'Q.or') as readonly Where<C>[],
   };
 }
@@ -251,6 +254,7 @@ export function on(table: string, ...args: readonly unknown[]): On {
     return {
       type: 'on',
       table: tableName,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the overloads make this the shorthand form; `where` validates the value itself, and the length check above proves the index.
       conditions: [where(first, args[1] as Value | Comparison)],
     };
   }
@@ -278,7 +282,7 @@ export function sortBy<C extends string>(
   }
   return {
     type: 'sortBy',
-    sortColumn: ensureName(sortColumn, 'column') as C,
+    sortColumn: ensureName(sortColumn, 'column'),
     sortOrder,
   };
 }

--- a/packages/core/src/query/encodeQuery.ts
+++ b/packages/core/src/query/encodeQuery.ts
@@ -151,6 +151,7 @@ export function encodeQuery(
         return `${col} <= ${encodeValueOrColumn(right, tableContext)}`;
       case 'between': {
         const values = valuesOf(right);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Q.between builds exactly two values, and only Q.between makes a 'between' comparison.
         return `${col} between ${pushArg(values[0]!)} and ${pushArg(values[1]!)}`;
       }
       case 'oneOf':
@@ -190,6 +191,7 @@ export function encodeQuery(
         const parts = clause.conditions.map((c) =>
           encodeCondition(c, clause.table),
         );
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by the length check on the same line.
         return parts.length === 1 ? parts[0]! : `(${parts.join(' and ')})`;
       }
       case 'sqlExpr':

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -406,6 +406,7 @@ function sharedStore<T>(
     registry = new Map();
     registries.set(database, registry);
   }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- one registry holds stores of every result type; the key is what pairs an entry with its T, and `make` builds the entry for this key.
   let store = registry.get(key) as
     ReturnType<typeof createStore<T>> | undefined;
   if (!store) {
@@ -421,6 +422,7 @@ function sharedStore<T>(
       snapshot: created.snapshot,
       idle: created.idle,
     };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the registry's value type is the erased store, which is why reading one back needs the assertion above.
     registry.set(key, store as ReturnType<typeof createStore<never>>);
   }
   return store;

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -229,6 +229,7 @@ export function table<const Cols extends ColumnsSpec>(
   name: string,
   cols: Cols,
 ): TableSchema<Cols> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- `buildTableSchema` erases the spec; TableSchema<Cols> re-states the columns this call was given.
   return buildTableSchema(name, columnsFromSpec(cols)) as TableSchema<Cols>;
 }
 

--- a/packages/core/src/schema/migrations.ts
+++ b/packages/core/src/schema/migrations.ts
@@ -115,7 +115,9 @@ export function schemaMigrations(spec: {
       );
     }
   });
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the empty check above.
   const first = migrations[0]!;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the empty check above.
   const last = migrations[migrations.length - 1]!;
   return deepFreeze({
     migrations: [...migrations],

--- a/packages/core/src/sync/applyRemote.ts
+++ b/packages/core/src/sync/applyRemote.ts
@@ -106,6 +106,7 @@ export async function applyRemoteChanges(
         ? await queryRows(database, table, [])
         : await queryRowsByIds(database, table, referencedIds);
       for (const row of rows) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- a driver row's values are SqlValue; every table's id column is text, and the cache throws on a row whose id is not a string.
         const id = row['id'] as string;
         if (row['_status'] === 'deleted') {
           localState.set(id, 'tombstone');
@@ -163,6 +164,7 @@ export async function applyRemoteChanges(
             `sync: server created '${table}/${id}' but it exists — treating as update`,
           );
         }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- 'live' is recorded in the same loop that fills liveRecords, so the two maps agree on this id.
         updateResolved(liveRecords.get(id)!, dirty);
       } else if (state === 'tombstone') {
         if (options.replacement) {
@@ -190,6 +192,7 @@ export async function applyRemoteChanges(
       const id = remoteId(dirty);
       const state = localState.get(id);
       if (state === 'live') {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- 'live' is recorded in the same loop that fills liveRecords, so the two maps agree on this id.
         updateResolved(liveRecords.get(id)!, dirty);
       } else if (state === 'tombstone') {
         // local deletion wins locally; it will be pushed later

--- a/packages/core/src/sync/helpers.ts
+++ b/packages/core/src/sync/helpers.ts
@@ -60,6 +60,7 @@ export async function tombstoneIds(
   const rows = await queryRows(database, table, [
     Q.where('_status', 'deleted'),
   ]);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- a driver row's values are SqlValue; every table's id column is text.
   return rows.map((row) => row['id'] as string);
 }
 

--- a/packages/core/src/sync/synchronize.ts
+++ b/packages/core/src/sync/synchronize.ts
@@ -237,7 +237,8 @@ async function runSynchronize(
       const result: unknown = await options.pullChanges(args, options.signal);
       return options.validatePullResult
         ? options.validatePullResult(result)
-        : (result as SyncPullResult);
+        : // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the app's transport answers `unknown`; `validatePullResult` is the opt-in check for apps that want one, and the wire spec is the contract otherwise.
+          (result as SyncPullResult);
     };
     let pullResult = await pull({
       cursor: pullCursor,
@@ -316,7 +317,8 @@ async function runSynchronize(
     );
     const pushResult = options.validatePushResult
       ? options.validatePushResult(unvalidatedPushResult)
-      : (unvalidatedPushResult as SyncPushResult);
+      : // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- as with the pull above: `validatePushResult` is the opt-in check, the wire spec is the contract otherwise.
+        (unvalidatedPushResult as SyncPushResult);
     if ('conflict' in pushResult) {
       log(`sync: push conflict (attempt ${attempt}/${retries}) — re-pulling`);
       continue;

--- a/packages/core/src/utils/checkName.ts
+++ b/packages/core/src/utils/checkName.ts
@@ -5,7 +5,10 @@ const IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
  * lets the SQL encoders interpolate identifiers into SQL text — everything
  * that doesn't match the strict pattern is rejected at construction time.
  */
-export function ensureName(name: string, kind: 'column' | 'table'): string {
+export function ensureName<S extends string>(
+  name: S,
+  kind: 'column' | 'table',
+): S {
   if (typeof name !== 'string' || !IDENTIFIER.test(name)) {
     throw new Error(
       // String() rather than plain interpolation: the guard above exists

--- a/packages/core/src/utils/randomId.ts
+++ b/packages/core/src/utils/randomId.ts
@@ -79,8 +79,9 @@ export function randomId(source?: RandomSource): string {
   const bytes = new Uint8Array(16);
   fillRandomValues(bytes, source);
   let id = '';
-  for (let i = 0; i < bytes.length; i++) {
-    id += ALPHABET[bytes[i]! % ALPHABET.length]!;
+  for (const byte of bytes) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the modulo keeps the index inside ALPHABET.
+    id += ALPHABET[byte % ALPHABET.length]!;
   }
   return id;
 }

--- a/packages/core/src/zod/index.ts
+++ b/packages/core/src/zod/index.ts
@@ -54,6 +54,7 @@ const columnFor = (key: string, field: z.ZodType): ColumnDef => {
   let nullable = false;
   if (inner instanceof z.ZodNullable) {
     nullable = true;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- zod types `unwrap()` by its own internals; the instanceof above is what says there is a ZodType inside.
     inner = inner.unwrap() as z.ZodType;
   }
   if (inner instanceof z.ZodOptional) {
@@ -112,9 +113,11 @@ export function zodTable<Shape extends z.ZodRawShape>(
   }
   const spec: Record<string, ColumnDef> = {};
   for (const [key, field] of Object.entries(schema.shape)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- a ZodRawShape's values are ZodTypes; Object.entries loses that.
     const def = columnFor(key, field as z.ZodType);
     spec[key] = indexed.has(key) ? def.indexed() : def;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ColumnsFor<Shape> re-states, at the type level, the mapping the loop above just performed.
   return table(name, spec as ColumnsSpec) as TableSchema<ColumnsFor<Shape>>;
 }
 
@@ -174,6 +177,7 @@ export function syncSchemas<
   // output never contains explicit-undefined entries (absent tables are
   // absent keys), so `SyncChanges` — the type `synchronize` and the
   // server engine take — is the honest static type.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- per the comment above: parse output never carries explicit-undefined entries.
   const changes = z
     .strictObject(changeSets)
     .partial() as unknown as z.ZodType<SyncChanges>;
@@ -199,6 +203,7 @@ export function syncSchemas<
   // Same story as `changes` for `rejected`: `.optional()` infers
   // `| undefined`, which JSON input can never produce, so the core
   // result type is the honest one (and the one `synchronize` takes).
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- per the comment above: `rejected` is absent or present, never explicitly undefined.
   const pushResult = z.union([
     z
       .strictObject({

--- a/packages/driver-node/src/NodeSqliteDriver.ts
+++ b/packages/driver-node/src/NodeSqliteDriver.ts
@@ -44,6 +44,7 @@ export class NodeSqliteDriver implements SqliteDriver {
     }
     this.db = db;
     this.name = name;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- better-sqlite3 types `pragma` as `unknown`; `user_version` is an integer by SQLite's own definition.
     const userVersion = db.pragma('user_version', { simple: true }) as number;
     return { userVersion };
   }
@@ -54,6 +55,7 @@ export class NodeSqliteDriver implements SqliteDriver {
   }
 
   async query(sql: string, args: SqlArgs): Promise<Row[]> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- better-sqlite3 types `all()` as `unknown[]`; the driver contract is that callers ask for columns SQLite can return.
     return this.openDb.prepare(sql).all(...bindArgs(args)) as Row[];
   }
 

--- a/packages/driver-rn-cpp/src/RnSqliteDriver.ts
+++ b/packages/driver-rn-cpp/src/RnSqliteDriver.ts
@@ -50,6 +50,7 @@ export class RnSqliteDriver implements SqliteDriver {
   }
 
   async query(sql: string, args: SqlArgs): Promise<Row[]> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- codegen types the row vocabulary as UnsafeMixed; the C++ side returns column-keyed objects and validates the shape.
     return NativeRemelonDriver.query(this.openName, sql, args) as Row[];
   }
 

--- a/packages/driver-rn/src/RnSqliteDriver.ts
+++ b/packages/driver-rn/src/RnSqliteDriver.ts
@@ -58,11 +58,11 @@ export class RnSqliteDriver implements SqliteDriver {
   }
 
   async query(sql: string, args: SqlArgs): Promise<Row[]> {
-    return this.openDb.getAllAsync<Row>(sql, args as SQLite.SQLiteBindValue[]);
+    return this.openDb.getAllAsync<Row>(sql, bindArgs(args));
   }
 
   async execute(sql: string, args: SqlArgs): Promise<void> {
-    await this.openDb.runAsync(sql, args as SQLite.SQLiteBindValue[]);
+    await this.openDb.runAsync(sql, bindArgs(args));
   }
 
   async executeBatch(statements: readonly BatchStatement[]): Promise<void> {
@@ -72,7 +72,7 @@ export class RnSqliteDriver implements SqliteDriver {
         const statement = await db.prepareAsync(sql);
         try {
           for (const args of argSets) {
-            await statement.executeAsync(args as SQLite.SQLiteBindValue[]);
+            await statement.executeAsync(bindArgs(args));
           }
         } finally {
           await statement.finalizeAsync();
@@ -101,3 +101,9 @@ export class RnSqliteDriver implements SqliteDriver {
     }
   }
 }
+
+// SqlValue is a subset of SQLiteBindValue, so the only mismatch is the seam's
+// `readonly` array against expo-sqlite's mutable parameter type; it binds the
+// values and never writes to the array.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- readonly-to-mutable only, no value-level narrowing.
+const bindArgs = (args: SqlArgs) => args as SQLite.SQLiteBindValue[];

--- a/packages/driver-web/src/WebSqliteDriver.ts
+++ b/packages/driver-web/src/WebSqliteDriver.ts
@@ -202,6 +202,7 @@ export class WebSqliteDriver implements SqliteDriver {
         },
         addMessageListener: (listener) => {
           shared.port.addEventListener('message', (event) => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- MessageEvent.data is `any` across the port boundary; the protocol module is the contract and the `control` check below discriminates.
             const data = event.data as WorkerResponse | BrokerControlMessage;
             if ('control' in data) {
               switch (data.control) {
@@ -361,6 +362,7 @@ export class WebSqliteDriver implements SqliteDriver {
     const id = this.nextId++;
     return new Promise<T>((resolve, reject) => {
       this.pending.set(id, {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- `pending` holds resolvers for every request type at once, so the map erases T; `request<T>` re-applies it at the call site.
         resolve: resolve as (value: unknown) => void,
         reject,
       });
@@ -369,6 +371,7 @@ export class WebSqliteDriver implements SqliteDriver {
   }
 
   private handleResponse(message: unknown): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the worker answers `unknown` over postMessage; the protocol module is the contract, and an unknown id falls out below.
     const response = message as WorkerResponse;
     const pending = this.pending.get(response.id);
     if (!pending) {

--- a/packages/driver-web/src/server.ts
+++ b/packages/driver-web/src/server.ts
@@ -42,6 +42,7 @@ const fromColumn = (value: unknown): SqlValue => {
   if (typeof value === 'bigint') {
     return Number(value);
   }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- wasm sqlite types column values as `unknown`; SqlValue is the vocabulary the seam defines for them, bigint having been handled above.
   return value as SqlValue;
 };
 
@@ -256,6 +257,7 @@ export function createSqliteWorkerServing(
   let queue: Promise<unknown> = serverPromise;
   return (endpoint) => {
     endpoint.addMessageListener((message) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- an endpoint delivers `unknown`; the protocol module is the contract, and the `op` check below drops anything else.
       const request = message as WorkerRequest;
       if (typeof (request as { op?: unknown }).op !== 'string') {
         return; // control traffic (port adoption), not a request

--- a/packages/driver-web/src/shared-worker.ts
+++ b/packages/driver-web/src/shared-worker.ts
@@ -57,6 +57,7 @@ interface Route {
   readonly onFailure?: () => void;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- SharedWorkerGlobalScope is not in this project's lib, so the connect event is declared here.
 const scope = globalThis as unknown as {
   addEventListener(
     type: 'connect',
@@ -294,16 +295,9 @@ const resetEpoch = (): void => {
   // whose own open is among the replayed requests are excluded — the
   // replay opens those itself.
   const replayedOpens = new Set(
-    pending
-      .concat(backlog.map((item) => ({ request: item.request })) as never[])
-      .filter(
-        (route) => (route as { request: WorkerRequest }).request.op === 'open',
-      )
-      .map(
-        (route) =>
-          ((route as { request: WorkerRequest }).request as { name: string })
-            .name,
-      ),
+    [...pending, ...backlog].flatMap(({ request }) =>
+      request.op === 'open' ? [request.name] : [],
+    ),
   );
   namesToRestore = [...holders.keys()].filter(
     (name) => !replayedOpens.has(name),
@@ -333,6 +327,7 @@ const adoptComputePort = (port: PortLike): void => {
   computePort = port;
   stopRecruitment();
   port.addEventListener('message', (event) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- MessageEvent.data is `any` across the port boundary; the protocol module is the contract, and an unrouted id falls out below.
     const response = event.data as WorkerResponse;
     const route = routes.get(response.id);
     if (!route) {
@@ -419,6 +414,7 @@ const send = (
   const base = { port, originalId: request.id, request };
   const route = transform ? { ...base, transform } : base;
   routes.set(routeId, onFailure ? { ...route, onFailure } : route);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `send` states a live compute channel as its precondition; callers backlog the request instead when there is none.
   computePort!.postMessage({ ...request, id: routeId });
   scheduleWatchdog();
 };
@@ -468,6 +464,7 @@ const heldExclusive = (): boolean =>
 
 const grantSlots = (): void => {
   while (slotQueue.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the loop condition is `slotQueue.length > 0`, so index 0 exists.
     const head = slotQueue[0]!;
     const canGrant = head.exclusive ? heldSlots.size === 0 : !heldExclusive();
     if (!canGrant) {
@@ -557,6 +554,7 @@ const handle = (port: PortLike, request: WorkerRequest): void => {
           },
           (rows) => ({
             userVersion: Number(
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- a transform receives the worker's result as `unknown`; this one reads the single column its own `pragma user_version` query selects.
               (rows as readonly { user_version?: unknown }[])[0]
                 ?.user_version ?? 0,
             ),
@@ -628,6 +626,7 @@ scope.addEventListener('connect', (event) => {
     return;
   }
   port.addEventListener('message', (messageEvent) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- MessageEvent.data is `any` across the port boundary; the protocol module is the contract and the control check below discriminates.
     const data = messageEvent.data as WorkerRequest | ClientControlMessage;
     // A control is never a request: anything carrying the field leaves
     // here, and the handoff branch is entered by name rather than by

--- a/packages/driver-web/src/worker.ts
+++ b/packages/driver-web/src/worker.ts
@@ -20,6 +20,7 @@ interface PortLike {
   start?(): void;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- DedicatedWorkerGlobalScope is not in this project's lib, so the worker scope's own postMessage/addEventListener are declared here.
 const scope = globalThis as unknown as {
   postMessage(message: unknown): void;
   addEventListener(
@@ -58,6 +59,7 @@ serve(endpoint);
 // Port adoption (docs/multi-tab.md): the spawning tab hands us a port
 // wired to the SharedWorker broker; the same server answers on it.
 scope.addEventListener('message', (event) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the message is `unknown` across the boundary; the optional field is read defensively below rather than trusted.
   const data = event.data as { __remelondbAdoptPort?: boolean } | null;
   const port = event.ports?.[0];
   if (data?.__remelondbAdoptPort === true && port) {

--- a/packages/nestjs/src/module.ts
+++ b/packages/nestjs/src/module.ts
@@ -101,6 +101,7 @@ export function syncEngineFromOptions<Scope>(
         name,
         {
           ...options.tableOptions?.[name],
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `name` iterates the keys of `options.tables`, and `wire.rows` is keyed by those same tables.
           validate: (row: unknown) => wire.rows[name]!.safeParse(row).success,
         },
       ]),
@@ -142,6 +143,7 @@ const prepare = <Scope>(options: RemelonSyncOptions<Scope>): SyncRuntime => {
       const parsed = wire.pullArgs.safeParse(body);
       if (!parsed.success)
         throw new BadRequestException('malformed pull request');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- SyncRuntime is deliberately non-generic; the scope reaching it came from this closure's own `scopeFrom`.
       return engine.as(scope as Scope).pull(parsed.data);
     },
     push: async (scope, body) => {
@@ -150,7 +152,9 @@ const prepare = <Scope>(options: RemelonSyncOptions<Scope>): SyncRuntime => {
         throw new BadRequestException('malformed push request');
       try {
         return await engine
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- as above: SyncRuntime erases Scope, the value came from this closure's own `scopeFrom`.
           .as(scope as Scope)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the envelope validates shape and ids only, on purpose (see above); the engine re-checks every row's values per table.
           .push(parsed.data as SyncPushArgs);
       } catch (error) {
         if (error instanceof SyncProtocolError) {

--- a/packages/server/src/conformance/index.ts
+++ b/packages/server/src/conformance/index.ts
@@ -122,6 +122,7 @@ const liveIds = (changes: SyncChanges, table: string): string[] => {
  */
 export const pulled = (result: SyncPullResult) => {
   expect(result).not.toHaveProperty('resyncRequired');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the expect above rules out the resyncRequired arm; the mutable shape is this helper's published return type.
   return result as { changes: SyncChanges; cursor: string };
 };
 /**
@@ -131,6 +132,7 @@ export const pulled = (result: SyncPullResult) => {
  */
 export const accepted = (result: SyncPushResult) => {
   expect(result).not.toHaveProperty('conflict');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the expect above rules out the conflict arm; the mutable shape is this helper's published return type.
   const ok = result as {
     cursor: string | null;
     changes: SyncChanges | null;
@@ -162,11 +164,11 @@ export const accepted = (result: SyncPushResult) => {
 export function registerServerConformance(
   options: ServerConformanceOptions,
 ): void {
-  const tables = Object.keys(options.fixtures);
-  if (tables.length === 0) {
+  const table = Object.keys(options.fixtures)[0];
+  if (table === undefined) {
     throw new Error('registerServerConformance: at least one table fixture');
   }
-  const table = tables[0]!;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `table` is one of `options.fixtures`' own keys.
   const fixture = options.fixtures[table]!;
   const changesWith = (
     rows: WireRow[],
@@ -375,6 +377,7 @@ export function registerServerConformance(
         await handlers.push({ changes: changesWith([mine]), cursor: myCursor }),
       );
       if (result.cursor !== null) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `accepted` asserts cursor and changes are both-or-neither, and this branch has a cursor.
         const ids = liveIds(result.changes!, table);
         expect(ids).toContain(foreign.id);
         expect(ids).not.toContain(mine.id);
@@ -505,7 +508,9 @@ export function registerServerConformance(
     case13(
       '13. a write to an existing id in an appendOnly table is rejected by id',
       async () => {
-        const { table: aoTable, fixture: aoFixture } = appendOnly!;
+        const { table: aoTable, fixture: aoFixture } =
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the case registers as `it.skip` when `options.appendOnly` is absent, so the body only runs when it is present.
+          appendOnly!;
         const { handlers } = await options.makeContext();
         const row = aoFixture.validRow();
         const changes = (rows: WireRow[], asUpdated = false): SyncChanges => ({
@@ -552,7 +557,9 @@ export function registerServerConformance(
     case14(
       '14. a storage constraint refusal is a per-record rejection, and the rest of the batch applies (needs `uniqueColumn`)',
       async (ctx) => {
-        const { table: uqTable, row: uqRow } = uniqueColumn!;
+        const { table: uqTable, row: uqRow } =
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the case registers as `it.skip` when `options.uniqueColumn` is absent, so the body only runs when it is present.
+          uniqueColumn!;
         const { handlers, secondUser } = await options.makeContext();
         if (!secondUser) return ctx.skip();
         const changes = (rows: WireRow[]): SyncChanges => ({
@@ -587,6 +594,7 @@ export function registerServerConformance(
         const recovered = accepted(
           await secondUser.push({
             changes: changes([uqRow('uq-b1', 'fresh')]),
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- a conformant backend answers an accepted push with a cursor; the degraded (null) case is its own scenario.
             cursor: collide.cursor!,
           }),
         );
@@ -599,7 +607,9 @@ export function registerServerConformance(
     caseCross(
       '15. a cross-validation refusal is reported in rejected and the row is not applied (needs `crossValidation`)',
       async () => {
-        const { table: cvTable, rejectedRow } = crossValidation!;
+        const { table: cvTable, rejectedRow } =
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the case registers as `it.skip` when `options.crossValidation` is absent, so the body only runs when it is present.
+          crossValidation!;
         const { handlers } = await options.makeContext();
         const bad = rejectedRow();
 
@@ -622,7 +632,9 @@ export function registerServerConformance(
     caseCross(
       '16. a cross-validation refusal of a deletion keeps the row alive (needs `crossValidation`)',
       async () => {
-        const { table: cvTable, undeletableRow } = crossValidation!;
+        const { table: cvTable, undeletableRow } =
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the case registers as `it.skip` when `options.crossValidation` is absent, so the body only runs when it is present.
+          crossValidation!;
         const { handlers } = await options.makeContext();
         const keystone = undeletableRow();
 
@@ -645,6 +657,7 @@ export function registerServerConformance(
             changes: {
               [cvTable]: { created: [], updated: [], deleted: [keystone.id] },
             },
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- a conformant backend answers an accepted push with a cursor; the degraded (null) case is its own scenario.
             cursor: seeded.cursor!,
           }),
         );
@@ -695,11 +708,9 @@ export function registerServerConformance(
     case18(
       '18. a refused deletion of a duplicated id rejects the id and keeps the pre-push content (needs `crossValidation`)',
       async () => {
-        const {
-          table: cvTable,
-          undeletableRow,
-          mutateUndeletableRow,
-        } = crossValidation!;
+        const { table: cvTable, undeletableRow, mutateUndeletableRow } =
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the case registers as `it.skip` when `options.crossValidation` is absent, so the body only runs when it is present.
+          crossValidation!;
         const { handlers } = await options.makeContext();
         const keystone = undeletableRow();
         const cvChanges = (
@@ -726,6 +737,7 @@ export function registerServerConformance(
         const denied = accepted(
           await handlers.push({
             changes: cvChanges([mutated], [keystone.id]),
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- a conformant backend answers an accepted push with a cursor; the degraded (null) case is its own scenario.
             cursor: seeded.cursor!,
           }),
         );

--- a/packages/server/src/conformance/referenceServer.ts
+++ b/packages/server/src/conformance/referenceServer.ts
@@ -154,6 +154,7 @@ export function createReferenceServer(
         const rows = tableOf(user, table);
         const validate = options.validate?.[table];
         for (const raw of [...change.created, ...change.updated]) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the wire contract gives every pushed record a string id; the engine rejects a push without one before a store ever sees it.
           const row = raw as DirtyRaw & { id: string };
           if (validate && !validate(row)) {
             (rejected[table] ??= []).push(row.id);

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -191,6 +191,7 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
               'sync push: record without a usable id',
             );
           }
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the check above proves `raw['id']` is a non-empty string, which is all WireRow adds to DirtyRaw.
           byId.set(id, raw as WireRow);
         }
         // a deletion is the terminal statement for its id: an id named in

--- a/packages/store-drizzle/src/fixture.ts
+++ b/packages/store-drizzle/src/fixture.ts
@@ -61,5 +61,6 @@ export const freshDb = async (): Promise<{ client: PGlite; db: DrizzleDb }> => {
       handle text unique
     );
   `);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- pglite's drizzle instance carries its own query-result HKT; DrizzleDb is the erased form the store accepts.
   return { client, db: drizzle(client) as unknown as DrizzleDb };
 };

--- a/packages/store-drizzle/src/store.ts
+++ b/packages/store-drizzle/src/store.ts
@@ -161,6 +161,7 @@ interface Prepared<Scope> {
 const fnv64 = (input: string): bigint => {
   let hash = 0xcbf29ce484222325n;
   for (const char of input) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `for...of` over a string yields one non-empty code point at a time, so index 0 exists.
     hash ^= BigInt(char.codePointAt(0)!);
     hash = BigInt.asUintN(64, hash * 0x100000001b3n);
   }
@@ -173,16 +174,25 @@ const rowsOf = (result: unknown): Record<string, unknown>[] =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   Array.isArray(result)
     ? result
-    : (result as { rows: Record<string, unknown>[] }).rows;
+    : // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the dialect's own result type, per the comment above.
+      (result as { rows: Record<string, unknown>[] }).rows;
 
 const excluded = (column: string): SQL => sql.raw(`excluded."${column}"`);
+
+// Drizzle infers an operator's operand type from a statically known column.
+// These columns arrive as runtime config (`PgColumn`), so that inference has
+// nothing to work with and collapses to `never`. Identity at runtime.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the reason is the paragraph above; it applies to every operand this store builds.
+const operand = (value: unknown) => value as never;
 
 const prepare = <Scope>(
   name: string,
   cfg: DrizzleTableConfig<Scope>,
 ): Prepared<Scope> => {
   const columns = getTableColumns(cfg.table);
-  const keyOf = (column: PgColumn | undefined): string | null => {
+  function keyOf(column: PgColumn): string;
+  function keyOf(column: PgColumn | undefined): string | null;
+  function keyOf(column: PgColumn | undefined): string | null {
     if (!column) return null;
     for (const [key, candidate] of Object.entries(columns)) {
       if (candidate === column) return key;
@@ -190,10 +200,10 @@ const prepare = <Scope>(
     throw new Error(
       `store-drizzle: table '${name}' config references a column not on its table`,
     );
-  };
-  const idKey = keyOf(cfg.id)!;
-  const revKey = keyOf(cfg.rev)!;
-  const deletedKey = keyOf(cfg.deletedAt)!;
+  }
+  const idKey = keyOf(cfg.id);
+  const revKey = keyOf(cfg.rev);
+  const deletedKey = keyOf(cfg.deletedAt);
   const scopeKey = keyOf(cfg.scope);
   if (!scopeKey) {
     const o = cfg.overrides ?? {};
@@ -228,6 +238,7 @@ const prepare = <Scope>(
       ((row) => {
         const wire: Record<string, unknown> = { id: row[idKey] };
         for (const column of userColumns) wire[column.name] = row[column.key];
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- WireRow adds only `id: string` to a raw row, and the id column is the table's text primary key.
         return wire as WireRow;
       }),
     fromWire:
@@ -303,6 +314,7 @@ export function createDrizzleStore<Scope>(
     const rows = rowsOf(
       await tx.execute(sql.raw(`select nextval('${sequence}') as rev`)),
     );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `select nextval(...)` returns exactly one row.
     return Number(rows[0]!['rev']);
   };
 
@@ -316,8 +328,9 @@ export function createDrizzleStore<Scope>(
         .from(p.cfg.table)
         .where(
           and(
-            eq(p.cfg.scope!, txScope as never),
-            gt(p.cfg.rev, since as never),
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `prepare` rejects a scope-less table unless it overrides this very method, and the override path returned above.
+            eq(p.cfg.scope!, operand(txScope)),
+            gt(p.cfg.rev, operand(since)),
           ),
         )) as Record<string, unknown>[];
       return rows.map((row) => ({
@@ -332,8 +345,10 @@ export function createDrizzleStore<Scope>(
         const contribution = p.cfg.overrides?.maxRev
           ? await p.cfg.overrides.maxRev(tx, txScope)
           : Number(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- a `coalesce(max(...), 0)` aggregate returns exactly one row.
               rowsOf(
                 await tx.execute(
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `prepare` rejects a scope-less table unless it overrides this very method, and the override path returned above.
                   sql`select coalesce(max(${p.cfg.rev}), 0) as rev from ${p.cfg.table} where ${p.cfg.scope!} = ${txScope}`,
                 ),
               )[0]!['rev'],
@@ -353,8 +368,9 @@ export function createDrizzleStore<Scope>(
         .from(p.cfg.table)
         .where(
           and(
-            inArray(p.cfg.id, [...ids] as never[]),
-            eq(p.cfg.scope!, txScope as never),
+            inArray(p.cfg.id, operand([...ids])),
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `prepare` rejects a scope-less table unless it overrides this very method, and the override path returned above.
+            eq(p.cfg.scope!, operand(txScope)),
           ),
         );
       return new Map(rows.map((row) => [String(row.id), Number(row.rev)]));
@@ -369,8 +385,9 @@ export function createDrizzleStore<Scope>(
         .from(p.cfg.table)
         .where(
           and(
-            inArray(p.cfg.id, [...ids] as never[]),
-            ne(p.cfg.scope!, txScope as never),
+            inArray(p.cfg.id, operand([...ids])),
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `prepare` rejects a scope-less table unless it overrides this very method, and the override path returned above.
+            ne(p.cfg.scope!, operand(txScope)),
           ),
         );
       return rows.map((row) => String(row.id));
@@ -385,9 +402,9 @@ export function createDrizzleStore<Scope>(
         .from(p.cfg.table)
         .where(
           and(
-            inArray(p.cfg.id, [...ids] as never[]),
+            inArray(p.cfg.id, operand([...ids])),
             isNotNull(p.cfg.deletedAt),
-            p.cfg.scope ? eq(p.cfg.scope, txScope as never) : undefined,
+            p.cfg.scope ? eq(p.cfg.scope, operand(txScope)) : undefined,
           ),
         );
       return rows.map((row) => String(row.id));
@@ -455,9 +472,9 @@ export function createDrizzleStore<Scope>(
         })
         .where(
           and(
-            inArray(p.cfg.id, [...ids] as never[]),
+            inArray(p.cfg.id, operand([...ids])),
             isNull(p.cfg.deletedAt),
-            p.cfg.scope ? eq(p.cfg.scope, txScope as never) : undefined,
+            p.cfg.scope ? eq(p.cfg.scope, operand(txScope)) : undefined,
           ),
         );
     },
@@ -470,6 +487,7 @@ export function createDrizzleStore<Scope>(
         sql.raw(`select value from ${meta} where key = 'gc_floor'`),
       ),
     );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by the length check on the same line.
     return rows.length === 0 ? 0 : Number(rows[0]!['value']);
   };
 
@@ -514,7 +532,7 @@ export function createDrizzleStore<Scope>(
             .where(
               and(
                 isNotNull(p.cfg.deletedAt),
-                lte(p.cfg.rev, effective as never),
+                lte(p.cfg.rev, operand(effective)),
               ),
             );
         }


### PR DESCRIPTION
Phase 2 of #53: every ratchet warning cleared, both rules now `error`, the CI ceiling at `--max-warnings 0`.

- 107 warnings resolved package by package, one commit each, the ceiling lowered per commit.
- 9 narrows/restructures where the type system could genuinely know (an `ensureName` generic, a `keyOf` overload, driver-rn's `bindArgs` helper, the shared-worker scan as one `flatMap`); the store-drizzle `operand()` identity helper replaces eleven identical drizzle-inference casts with one stated reason.
- The remaining disables each carry a one-line reason, in four classes: SQLite/ORM d.ts gaps, message/transport boundaries where the protocol module is the contract, public API variance knots, and provably-in-bounds index access under `noUncheckedIndexedAccess`.
- Deliberately kept: `collection.cache.get(id)!` in Database (the identity-map invariant is worth more than removing a comment line).

Verified: lint 0/0, 429 tests, typecheck, build, prettier; the browser suite (47 passed) covered the one restructure inside live recovery logic.

Note for CI: two pglite conformance tests flaked once when vitest and eslint ran concurrently on a loaded box; serialized runs are stable.
