### PR TITLE
fix(server): enforce push pipeline ordering

### DIFF
--- a/docs/sync-wire.md
+++ b/docs/sync-wire.md
@@ -32,7 +32,7 @@ transport that delivers these values conforms.
   NOT appear on the wire in either direction; unknown keys are dropped
   by the client's sanitizer, not errors.
 - **ChangeSet** — `{ created: Record[], updated: Record[], deleted:
-  RecordId[] }`. `deleted` carries ids only.
+RecordId[] }`. `deleted` carries ids only.
 - **Changes** — `{ [tableName]: ChangeSet }`. Tables absent from the
   object mean "no changes there".
 
@@ -116,9 +116,11 @@ Semantics:
   together or none do.
 - **Conflict.** If any pushed record was modified on the server after
   the request's cursor, the server MUST reject the whole push with
-  `conflict` and apply nothing. The client then pulls (merging
-  per-column, local dirty columns winning), and pushes again — a
-  bounded loop (default 5 rounds) before surfacing an error.
+  `conflict` and apply nothing. This check covers every requested record in
+  the authenticated scope before validation can reject it. The client then
+  pulls (merging per-column, local dirty columns winning), and pushes again —
+  a bounded loop (default 5 rounds) before surfacing an error. A cursor beyond
+  the server's current horizon is also a conflict.
 - **Rejected records (partial accept).** A server MAY refuse individual
   records (validation, authorization, uniqueness) by listing their ids
   in `rejected` while accepting the rest. Rejected records' effects
@@ -134,17 +136,17 @@ Semantics:
 - **Cursor and interleaved changes are a package.** A non-null `cursor`
   MUST identify the push transaction's snapshot and MUST be accompanied
   by `changes`: everything committed between the request cursor and
-  that snapshot, excluding the push's own records. Returning a cursor
-  without those foreign changes reintroduces the lost-write race
-  through the back door. The client applies `changes`, marks synced,
-  adopts `cursor` — its own writes never echo.
+  that snapshot, excluding the push's own records by table and id.
+  Returning a cursor without those foreign changes reintroduces the
+  lost-write race through the back door. The client applies `changes`,
+  marks synced, adopts `cursor` — its own writes never echo.
 - **Degraded mode is legal — and sometimes mandatory.** `cursor: null,
-  changes: null` means "the server applied the push but cannot compute
+changes: null` means "the server applied the push but cannot compute
   the interleave". The client keeps its old cursor; the next pull
   re-delivers the push echo, which apply absorbs by equality. Correct
   either way — the fast path is a per-backend upgrade, invisible to app
   code. A server MUST degrade whenever it cannot compute the interleave
-  *completely* — in particular when the request cursor predates its
+  _completely_ — in particular when the request cursor predates its
   tombstone/change-log retention floor: the window has lost deletions,
   a "complete as far as we know" interleave would silently resurrect a
   deleted record on the client, and the degraded path routes the client
@@ -167,11 +169,12 @@ A conforming backend:
    never with silently incomplete data.
 4. Applies pushes atomically; answers `conflict` when any pushed record
    is stale; applies nothing on conflict.
-5. Never returns a push cursor without the *complete* interleaved
+5. Never returns a push cursor without the _complete_ interleaved
    foreign changes (degraded `null`/`null` is the escape hatch, and is
    mandatory when the request cursor predates the retention floor).
 6. Excludes rejected records' effects entirely; rejection lists name
-   ids that exist in the request.
+   ids that exist in the request under a configured table. Conflict
+   detection runs before rejection for every requested non-foreign id.
 7. Scopes every response to the authenticated client's data.
 
 ## 5. What servers may rely on from the client
@@ -207,7 +210,7 @@ For a server test suite; each item is one scenario or property test.
 2. Incremental pull returns exactly the rows changed after the cursor.
 3. Deletions arrive as ids in `deleted`; deleted rows never appear as
    records.
-4. A change committing *during* a pull (concurrent transaction) is
+4. A change committing _during_ a pull (concurrent transaction) is
    returned by the next pull — never lost. (The commit-order property;
    needs an interleaving harness or property test.)
 5. Push replay: identical push applied twice yields identical server
@@ -226,10 +229,10 @@ For a server test suite; each item is one scenario or property test.
 13. In a table declared `appendOnly`, a write to an existing id is
     rejected by id and the stored row is unchanged. Opt-in, so the
     suite runs it only when the backend declares such a table — and it
-    must be declared through the backend's *own* registration, which is
+    must be declared through the backend's _own_ registration, which is
     what catches a transport that drops engine config on the way to its
     endpoints.
-14. A refusal originating in *storage itself*, a unique or foreign-key
+14. A refusal originating in _storage itself_, a unique or foreign-key
     constraint the database enforces, is named in `rejected` like any
     other refusal, never a thrown error: the refused row leaves no
     trace, the rest of the push applies, and the same id retried with
@@ -239,7 +242,7 @@ For a server test suite; each item is one scenario or property test.
     the row is not applied. Opt-in (`crossValidation`): the backend
     mounts its own hook, so the case proves the hook wiring survives
     the registrant's whole stack.
-16. A cross-validation refusal of a *deletion* is reported by id and
+16. A cross-validation refusal of a _deletion_ is reported by id and
     the row stays alive: a server that reports the refusal but applies
     the tombstone anyway diverges every other device. Same opt-in.
 17. An id named in `deleted` supersedes its created/updated content in
@@ -248,8 +251,12 @@ For a server test suite; each item is one scenario or property test.
     to nothing.
 18. When the surviving statement for a duplicated id is refused (a
     deletion the cross-validation hook denies), the id is rejected and
-    the row keeps its *pre-push* content: the superseded update leaves
+    the row keeps its _pre-push_ content: the superseded update leaves
     no trace either. Opt-in (`crossValidation`).
+19. A stale record answers `conflict` even when validation would reject
+    its submitted value.
+20. Interleave exclusion is keyed by table and id: pushing `tableA/id`
+    does not hide an interleaved change to `tableB/id`.
 
 ## Versioning
 

--- a/packages/server/src/conformance/index.ts
+++ b/packages/server/src/conformance/index.ts
@@ -751,5 +751,73 @@ export function registerServerConformance(
         expect(stored).toEqual(keystone);
       },
     );
+
+    const case19 = fixture.invalidRow ? it : it.skip;
+    case19(
+      '19. conflict dominates validation rejection for the same id (needs `invalidRow`)',
+      async () => {
+        const { handlers } = await options.makeContext();
+        const row = fixture.validRow();
+        const staleCursor = pulled(await pullNull(handlers)).cursor;
+
+        accepted(
+          await handlers.push({
+            changes: changesWith([row]),
+            cursor: staleCursor,
+          }),
+        );
+
+        const invalid = {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the case registers as `it.skip` when `fixture.invalidRow` is absent, so the body only runs when it is present.
+          ...fixture.invalidRow!(),
+          id: row.id,
+        };
+        const result = await handlers.push({
+          changes: changesWith([invalid], [], true),
+          cursor: staleCursor,
+        });
+
+        expect(result).toEqual({ conflict: true });
+      },
+    );
+
+    const case20 = appendOnly ? it : it.skip;
+    case20(
+      '20. the push interleave keeps a matching id from another table (needs `appendOnly`)',
+      async () => {
+        const { table: otherTable, fixture: otherFixture } =
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the case registers as `it.skip` when `options.appendOnly` is absent, so the body only runs when it is present.
+          appendOnly!;
+        const { handlers } = await options.makeContext();
+        const row = fixture.validRow();
+        const otherRow = { ...otherFixture.validRow(), id: row.id };
+        const staleCursor = pulled(await pullNull(handlers)).cursor;
+
+        accepted(
+          await handlers.push({
+            changes: {
+              [otherTable]: {
+                created: [otherRow],
+                updated: [],
+                deleted: [],
+              },
+            },
+            cursor: staleCursor,
+          }),
+        );
+
+        const result = accepted(
+          await handlers.push({
+            changes: changesWith([row]),
+            cursor: staleCursor,
+          }),
+        );
+        expect(result.changes).not.toBeNull();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the assertion above narrows the runtime contract; TypeScript does not narrow through Vitest's matcher.
+        expect(liveIds(result.changes!, otherTable)).toContain(row.id);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- same assertion as above; this verifies the pushed row itself remains excluded.
+        expect(liveIds(result.changes!, table)).not.toContain(row.id);
+      },
+    );
   });
 }

--- a/packages/server/src/conformance/referenceServer.ts
+++ b/packages/server/src/conformance/referenceServer.ts
@@ -83,20 +83,21 @@ export function createReferenceServer(
   const changesSince = (
     user: string,
     since: number,
-    exclude: ReadonlySet<string>,
+    exclude: ReadonlyMap<string, ReadonlySet<string>>,
   ): SyncChanges => {
     const changes: Record<
       string,
       { created: DirtyRaw[]; updated: DirtyRaw[]; deleted: string[] }
     > = {};
     for (const [table, rows] of tablesOf(user)) {
+      const excludeIds = exclude.get(table);
       const set = {
         created: [],
         updated: [],
         deleted: [],
       } as (typeof changes)[string];
       for (const stored of rows.values()) {
-        if (stored.rev <= since || exclude.has(stored.row.id)) continue;
+        if (stored.rev <= since || excludeIds?.has(stored.row.id)) continue;
         if (stored.deleted) set.deleted.push(stored.row.id);
         else set.updated.push(stored.row);
       }
@@ -124,7 +125,7 @@ export function createReferenceServer(
       }
       const effectiveSince = args.migration !== null ? 0 : since;
       return {
-        changes: changesSince(user, effectiveSince, new Set()),
+        changes: changesSince(user, effectiveSince, new Map()),
         cursor: String(Math.max(since, maxRevOf(user))),
       };
     },
@@ -132,17 +133,21 @@ export function createReferenceServer(
       const since = decodeCursor(args.cursor);
       if (since === null) return { conflict: true };
 
-      const requestIds = new Set<string>();
-      for (const change of Object.values(args.changes)) {
+      const requestIds = new Map<string, Set<string>>();
+      for (const [table, change] of Object.entries(args.changes)) {
+        const ids = new Set<string>();
         for (const row of [...change.created, ...change.updated]) {
-          requestIds.add(String(row['id']));
+          ids.add(String(row['id']));
         }
-        for (const id of change.deleted) requestIds.add(id);
+        for (const id of change.deleted) ids.add(id);
+        requestIds.set(table, ids);
       }
       // conflict dominates: any pushed record already past the cursor
-      for (const rows of tablesOf(user).values()) {
+      for (const [table, rows] of tablesOf(user)) {
+        const ids = requestIds.get(table);
+        if (!ids) continue;
         for (const stored of rows.values()) {
-          if (requestIds.has(stored.row.id) && stored.rev > since) {
+          if (ids.has(stored.row.id) && stored.rev > since) {
             return { conflict: true };
           }
         }

--- a/packages/server/src/engine.test.ts
+++ b/packages/server/src/engine.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { registerServerConformance } from './conformance/index';
-import { createMemoryStore, createSyncEngine } from './index';
+import {
+  createMemoryStore,
+  createSyncEngine,
+  SyncProtocolError,
+  type SyncStore,
+} from './index';
 
 // The engine over the memory store must pass the full backend contract;
 // a real adapter proves itself the same way, engine included.
@@ -258,5 +263,79 @@ describe('cross-change validation', () => {
     ).rejected;
     expect(rejected?.cards).toEqual(['c1']);
     expect(rejected?.decks).toEqual(['d1']);
+  });
+});
+
+describe('push pipeline guards', () => {
+  const changes = {
+    tasks: {
+      created: [{ id: 't1', name: 'task' }],
+      updated: [],
+      deleted: [],
+    },
+  };
+
+  it('rejects a cursor beyond the scope horizon', async () => {
+    const handlers = createSyncEngine({
+      store: createMemoryStore(),
+      tables: { tasks: {} },
+    }).as('scope-a');
+
+    expect(await handlers.push({ changes, cursor: '999' })).toEqual({
+      conflict: true,
+    });
+  });
+
+  it.each([
+    {
+      name: 'unknown table',
+      rejected: { ghosts: ['t1'] },
+    },
+    {
+      name: 'id absent from the request',
+      rejected: { tasks: ['other'] },
+    },
+  ])('throws when a hook rejects an $name', async ({ rejected }) => {
+    const handlers = createSyncEngine({
+      store: createMemoryStore(),
+      tables: { tasks: {} },
+      crossValidate: async () => rejected,
+    }).as('scope-a');
+
+    await expect(handlers.push({ changes, cursor: '0' })).rejects.toMatchObject(
+      {
+        name: 'SyncProtocolError',
+        code: 'invalid-rejection',
+      } satisfies Partial<SyncProtocolError>,
+    );
+  });
+
+  it('degrades when gc advances while the interleave is collected', async () => {
+    let floor = 0;
+    const store: SyncStore<string> = {
+      transaction: async (_scope, _mode, work) =>
+        work({
+          changedSince: async () => {
+            floor = 1;
+            return [];
+          },
+          maxRev: async () => 1,
+          currentRevs: async () => new Map(),
+          foreignIds: async () => [],
+          tombstonedIds: async () => [],
+          upsert: async () => undefined,
+          tombstone: async () => undefined,
+          gcFloor: async () => floor,
+        }),
+    };
+    const handlers = createSyncEngine({
+      store,
+      tables: { tasks: {} },
+    }).as('scope-a');
+
+    expect(await handlers.push({ changes: {}, cursor: '0' })).toEqual({
+      cursor: null,
+      changes: null,
+    });
   });
 });

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -207,16 +207,8 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
         // the conflict scan must see all of them, or a row rejected here
         // escapes the stale check and its newer server rev is never
         // delivered (permanent divergence)
-        let allIds = [...byId.keys(), ...deletes];
-        const rows: WireRow[] = [];
-        for (const row of byId.values()) {
-          if (options.tables[table]?.validate?.(row) === false) {
-            (rejected[table] ??= []).push(row.id);
-          } else {
-            rows.push(row);
-          }
-        }
-        return { table, rows, deletes, allIds };
+        const allIds = [...byId.keys(), ...deletes];
+        return { table, rows: [...byId.values()], deletes, allIds };
       });
 
       return options.store.transaction(scope, 'push', async (tx) => {
@@ -256,6 +248,16 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
           for (const rev of revs.values()) {
             if (rev > since) return { conflict: true };
           }
+        }
+
+        for (const entry of parsed) {
+          const validate = options.tables[entry.table]?.validate;
+          if (!validate) continue;
+          entry.rows = entry.rows.filter((row) => {
+            if (validate(row)) return true;
+            (rejected[entry.table] ??= []).push(row.id);
+            return false;
+          });
         }
 
         // A hook may only reject ids that are in the request, keyed by a

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -25,7 +25,7 @@ export interface SyncHandlers {
  */
 export class SyncProtocolError extends Error {
   constructor(
-    readonly code: 'unusable-id',
+    readonly code: 'unusable-id' | 'invalid-rejection',
     message: string,
   ) {
     super(message);
@@ -82,7 +82,7 @@ const decodeCursor = (cursor: string): number | null => {
 
 const toChanges = (
   byTable: ReadonlyMap<string, readonly StoredChange[]>,
-  exclude: ReadonlySet<string>,
+  exclude: ReadonlyMap<string, ReadonlySet<string>>,
 ): SyncChanges => {
   const changes: Record<
     string,
@@ -94,8 +94,9 @@ const toChanges = (
       updated: [],
       deleted: [],
     } as (typeof changes)[string];
+    const excludeIds = exclude.get(table);
     for (const change of stored) {
-      if (exclude.has(change.id)) continue;
+      if (excludeIds?.has(change.id)) continue;
       if (change.row === null) set.deleted.push(change.id);
       else set.updated.push(change.row);
     }
@@ -160,7 +161,7 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
         return {
           changes: toChanges(
             await collectSince(tx, scope, effectiveSince),
-            new Set(),
+            new Map(),
           ),
           cursor: String(Math.max(since, effMax)),
         };
@@ -202,6 +203,11 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
         // one of its effects anyway
         const deletes = [...new Set(change?.deleted ?? [])];
         for (const id of deletes) byId.delete(id);
+        // every id this changeset names, before validation splits it —
+        // the conflict scan must see all of them, or a row rejected here
+        // escapes the stale check and its newer server rev is never
+        // delivered (permanent divergence)
+        let allIds = [...byId.keys(), ...deletes];
         const rows: WireRow[] = [];
         for (const row of byId.values()) {
           if (options.tables[table]?.validate?.(row) === false) {
@@ -210,28 +216,75 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
             rows.push(row);
           }
         }
-        return { table, rows, deletes };
+        return { table, rows, deletes, allIds };
       });
 
       return options.store.transaction(scope, 'push', async (tx) => {
-        // ownership rejections precede the stale check: cursors are
-        // horizons over the scope's own rows, so a foreign row's rev is
-        // incomparable and must not force conflict loops
+        // A push cursor above the served max cannot be honest: `rev >
+        // since` would never fire and the conflict scan would be
+        // disabled wholesale. Reject it, as the reference server does.
+        const effMax = Math.max(await tx.maxRev(scope), await tx.gcFloor());
+        if (since > effMax) return { conflict: true };
+
+        // Ownership first: a foreign row is not this scope's, so its rev
+        // is incomparable to a scope-horizon cursor. Reject and exclude
+        // it from the conflict scan and everything after.
         for (const entry of parsed) {
-          const ids = [...entry.rows.map((r) => r.id), ...entry.deletes];
-          if (ids.length === 0) continue;
-          const foreign = new Set(await tx.foreignIds(entry.table, scope, ids));
+          if (entry.allIds.length === 0) continue;
+          const foreign = new Set(
+            await tx.foreignIds(entry.table, scope, entry.allIds),
+          );
           if (foreign.size > 0) {
             (rejected[entry.table] ??= []).push(...foreign);
             entry.rows = entry.rows.filter((r) => !foreign.has(r.id));
             entry.deletes = entry.deletes.filter((id) => !foreign.has(id));
+            entry.allIds = entry.allIds.filter((id) => !foreign.has(id));
           }
         }
+
+        // Conflict dominates, and it is checked over EVERY non-foreign
+        // requested id — including ids a later step will reject. A row
+        // modified server-side after the cursor answers conflict before
+        // it is ever judged stale, so the client re-pulls the newer
+        // content instead of silently advancing its cursor past it. The
+        // revs are kept for the append-only check below.
+        const revsByTable = new Map<string, ReadonlyMap<string, number>>();
+        for (const entry of parsed) {
+          if (entry.allIds.length === 0) continue;
+          const revs = await tx.currentRevs(entry.table, scope, entry.allIds);
+          revsByTable.set(entry.table, revs);
+          for (const rev of revs.values()) {
+            if (rev > since) return { conflict: true };
+          }
+        }
+
+        // A hook may only reject ids that are in the request, keyed by a
+        // table that exists: a phantom id would tell the client to keep
+        // a record it has no dirty copy of and drop the real one from the
+        // interleave. A violation is a server bug, surfaced as one.
+        const requestedByTable = new Map(
+          parsed.map((entry) => [entry.table, new Set(entry.allIds)]),
+        );
         const applyExtraRejections = (extra: {
           readonly [table: string]: readonly string[];
         }): void => {
           for (const [table, ids] of Object.entries(extra)) {
             if (ids.length === 0) continue;
+            const requested = requestedByTable.get(table);
+            if (!requested) {
+              throw new SyncProtocolError(
+                'invalid-rejection',
+                `sync push: hook rejected ids for unknown table '${table}'`,
+              );
+            }
+            for (const id of ids) {
+              if (!requested.has(id)) {
+                throw new SyncProtocolError(
+                  'invalid-rejection',
+                  `sync push: hook rejected '${table}/${id}', not in the request`,
+                );
+              }
+            }
             const drop = new Set(ids);
             (rejected[table] ??= []).push(...ids);
             const entry = parsed.find((p) => p.table === table);
@@ -261,23 +314,10 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
           );
         }
 
-        // conflict dominates what remains (the contract's MUST)
-        const revsByTable = new Map<string, ReadonlyMap<string, number>>();
-        for (const entry of parsed) {
-          const ids = [...entry.rows.map((r) => r.id), ...entry.deletes];
-          if (ids.length === 0) continue;
-          const revs = await tx.currentRevs(entry.table, scope, ids);
-          revsByTable.set(entry.table, revs);
-          for (const rev of revs.values()) {
-            if (rev > since) return { conflict: true };
-          }
-        }
-
-        // past the conflict check every named rev is <= cursor, so a
-        // write aimed at a tombstone would silently no-op in the store
-        // (upsert MUST NOT resurrect) and an append-only table would
-        // swallow the change; both must be visible in `rejected` or the
-        // client marks a refused write as synced and diverges for good
+        // Every named rev is now <= cursor, so a write aimed at a
+        // tombstone would silently no-op (upsert MUST NOT resurrect) and
+        // an append-only table would swallow it; both must be visible in
+        // `rejected` or the client marks a refused write as synced.
         for (const entry of parsed) {
           if (entry.rows.length === 0) continue;
           const drop = new Set(
@@ -296,8 +336,6 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
           if (drop.size > 0) {
             (rejected[entry.table] ??= []).push(...drop);
             entry.rows = entry.rows.filter((r) => !drop.has(r.id));
-            // a rejected id leaves no effect: unreachable after the
-            // deleted-supersedes normalization, kept as the invariant
             entry.deletes = entry.deletes.filter((id) => !drop.has(id));
           }
         }
@@ -306,12 +344,8 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
           if (entry.rows.length > 0) {
             const refused = await tx.upsert(entry.table, scope, entry.rows);
             if (refused && refused.length > 0) {
-              // storage said no (constraint violation): same lane as
-              // validation refusals — never silent, never a 500
               (rejected[entry.table] ??= []).push(...refused);
               const drop = new Set(refused);
-              // a rejected id leaves no effect: unreachable after the
-              // deleted-supersedes normalization, kept as the invariant
               entry.deletes = entry.deletes.filter((id) => !drop.has(id));
             }
           }
@@ -324,25 +358,31 @@ export function createSyncEngine<Scope>(options: SyncEngineOptions<Scope>): {
 
         const rejectedField =
           Object.keys(rejected).length > 0 ? { rejected } : {};
+
+        // Collect the interleave, THEN read the floor: a gc committing
+        // during the collect prunes deletions from the window and raises
+        // the floor past them, so reading the floor after the collect
+        // turns that race into an honest degrade instead of a lost
+        // delete. The exclusion is keyed by (table, id): a bare id set
+        // would suppress the same id in a different table.
+        const collected = await collectSince(tx, scope, since);
         const floor = await tx.gcFloor();
-        // the fast path needs the COMPLETE interleave; below the floor
-        // deletions are gone from the window — degrade (the obligation
-        // the formal model found)
         if (since < floor) {
           return { cursor: null, changes: null, ...rejectedField };
         }
-        const requestIds = new Set(
-          parsed
-            .flatMap((entry) => [
+        const requestIds = new Map<string, ReadonlySet<string>>(
+          parsed.map((entry) => [
+            entry.table,
+            new Set([
               ...entry.rows.map((r) => r.id),
               ...entry.deletes,
-            ])
-            .concat(Object.values(rejected).flat()),
+              ...(rejected[entry.table] ?? []),
+            ]),
+          ]),
         );
         return {
-          // never issue a cursor below the floor (same rule as pull)
           cursor: String(Math.max(await tx.maxRev(scope), floor)),
-          changes: toChanges(await collectSince(tx, scope, since), requestIds),
+          changes: toChanges(collected, requestIds),
           ...rejectedField,
         };
       });

--- a/packages/store-drizzle/src/store.constraint.test.ts
+++ b/packages/store-drizzle/src/store.constraint.test.ts
@@ -114,9 +114,10 @@ describe('constraint violations surface as per-record rejections', () => {
 
     // updating your own row keeps its handle: upsert on the same id is an
     // update, not a second insert, so no self-collision
+    const currentA = pulled(await userA.pull(pullArgs));
     const named = accepted(
       await userA.push({
-        cursor: bothNull.cursor!,
+        cursor: currentA.cursor,
         changes: profileChanges([{ id: 'a1', handle: 'kept' }]),
       }),
     );


### PR DESCRIPTION
## Summary

- bound push cursors to the authenticated scope's current horizon
- check conflicts for every non-foreign requested id before validation or rejection
- reject invalid hook output instead of silently accepting unknown tables or ids
- exclude push echoes by table and id
- reread the GC floor after collecting interleaved changes
- add regression and conformance coverage for the repaired invariants

The wire shape is unchanged.

## Verification

- `pnpm exec vitest run` (459 passed, 17 skipped)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:wire` (20/20)
- Prettier check on changed files
- `git diff --check`

Closes #56
